### PR TITLE
devicetree: marble-sm7475: Disable aw882xx cali mode for marble

### DIFF
--- a/qcom/Makefile
+++ b/qcom/Makefile
@@ -9,11 +9,13 @@ cupid-sm8450-pm8008-overlay.dtbo-base := waipio.dtb waipiop.dtb waipio-v2.dtb wa
 dtbo-$(CONFIG_ARCH_CAPE) += \
 	unicorn-sm8475-pm8008-overlay.dtbo \
 	thor-sm8475-pm8008-overlay.dtbo \
+	marble-sm7475-pm8008-overlay.dtbo \
 	mayfly-sm8475-pm8008-overlay.dtbo \
 	mondrian-sm8475-pm8008-overlay.dtbo
 
 unicorn-sm8475-pm8008-overlay.dtbo-base := cape.dtb cape-v2.dtb capep.dtb
 thor-sm8475-pm8008-overlay.dtbo-base := cape.dtb cape-v2.dtb capep.dtb
+marble-sm7475-pm8008-overlay.dtbo-base := ukee.dtb
 mayfly-sm8475-pm8008-overlay.dtbo-base := cape.dtb cape-v2.dtb capep.dtb
 mondrian-sm8475-pm8008-overlay.dtbo-base := cape.dtb cape-v2.dtb capep.dtb
 else
@@ -327,6 +329,7 @@ dtbo-$(CONFIG_ARCH_CAPE) += cape-mtp-pm8008-overlay.dtbo \
 	ukee-mtp-nodisplay-pm8010-overlay.dtbo \
 	ukee-qrd-pm8008-overlay.dtbo \
 	ukee-qrd-pm8010-overlay.dtbo \
+	marble-sm7475-pm8008-overlay.dtbo \
 	mondrian-sm8475-pm8008-overlay.dtbo
 
 
@@ -364,6 +367,7 @@ ukee-qrd-pm8008-overlay.dtbo-base := ukee.dtb
 ukee-qrd-pm8010-overlay.dtbo-base := ukee.dtb
 unicorn-sm8475-pm8008-overlay.dtbo-base := cape.dtb cape-v2.dtb capep.dtb
 thor-sm8475-pm8008-overlay.dtbo-base := cape.dtb cape-v2.dtb capep.dtb
+marble-sm7475-pm8008-overlay.dtbo-base := ukee.dtb
 mayfly-sm8475-pm8008-overlay.dtbo-base := cape.dtb cape-v2.dtb capep.dtb
 mondrian-sm8475-pm8008-overlay.dtbo-base := cape.dtb cape-v2.dtb capep.dtb
 

--- a/qcom/audio/Kbuild
+++ b/qcom/audio/Kbuild
@@ -53,6 +53,7 @@ dtbo-$(CONFIG_ARCH_CAPE) += cape-audio.dtbo \
                  ukee-audio-cdp.dtbo \
                  unicorn-audio.dtbo \
                  thor-audio.dtbo \
+                 marble-audio.dtbo \
                  mayfly-audio.dtbo \
                  mondrian-audio.dtbo
 

--- a/qcom/audio/marble-audio.dts
+++ b/qcom/audio/marble-audio.dts
@@ -1,0 +1,26 @@
+/dts-v1/;
+/plugin/;
+
+#include "xiaomi-sm8450-common.dtsi"
+
+/ {
+	model = "Qualcomm Technologies, Inc. Ukee MTP";
+	compatible = "qcom,ukee-mtp", "qcom,ukee", "qcom,mtp";
+	qcom,msm-id = <591 0x10000>;
+	qcom,board-id = <0x10008 0>;
+	xiaomi,miboard-id = <0xF 0>;
+};
+
+&waipio_snd {
+	/delete-property/qcom,uart-audio-sw-gpio;
+	qcom,model = "ukee-mtp-snd-card";
+};
+
+&swr_haptics {
+	status = "ok";
+};
+
+&adsp_loader {
+	adsp-fuse-not-supported = <1>;
+	adsp-fw-name = "adsp2.mdt";
+};

--- a/qcom/audio/ukee-audio-mtp.dts
+++ b/qcom/audio/ukee-audio-mtp.dts
@@ -8,4 +8,5 @@
 	compatible = "qcom,ukee-mtp", "qcom,ukee", "qcom,mtp";
 	qcom,msm-id = <591 0x10000>;
 	qcom,board-id = <0x10008 0>;
+	xiaomi,miboard-id = <0x1000 0>;
 };

--- a/qcom/camera/config/waipio.mk
+++ b/qcom/camera/config/waipio.mk
@@ -21,5 +21,6 @@ dtbo-$(CONFIG_ARCH_CAPE) += cape-camera-sensor-mtp.dtbo \
 
 dtbo-$(CONFIG_ARCH_CAPE) += ukee-camera-sensor-mtp.dtbo \
 				ukee-camera-sensor-cdp.dtbo \
-				ukee-camera-sensor-qrd.dtbo
+				ukee-camera-sensor-qrd.dtbo \
+				marble-sm7475-camera-sensor.dtbo
 dtbo-$(CONFIG_ARCH_CAPE) += ukee-camera.dtbo

--- a/qcom/camera/marble-sm7475-camera-sensor.dts
+++ b/qcom/camera/marble-sm7475-camera-sensor.dts
@@ -7,11 +7,11 @@
 #include <dt-bindings/interrupt-controller/arm-gic.h>
 #include <dt-bindings/regulator/qcom,rpmh-regulator-levels.h>
 
-#include "ukee-camera-sensor-mtp.dtsi"
+#include "marble-sm7475-camera-sensor.dtsi"
 / {
 	model = "Qualcomm Technologies, Inc. Ukee MTP";
 	compatible = "qcom,ukee-mtp", "qcom,ukee", "qcom,mtp";
 	qcom,msm-id = <591 0x10000>;
 	qcom,board-id = <8 0>, <0x10008 0>, <0x10008 2>, <0x10008 3>;
-	xiaomi,miboard-id = <0x1000 0>;
+	xiaomi,miboard-id = <0xF 0>;
 };

--- a/qcom/camera/marble-sm7475-camera-sensor.dtsi
+++ b/qcom/camera/marble-sm7475-camera-sensor.dtsi
@@ -1,0 +1,837 @@
+#include <dt-bindings/clock/qcom,camcc-waipio.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/msm-camera.h>
+
+&cci1_active {
+	config {
+		pins = "gpio112", "gpio113";
+		bias-pull-up; /* PULL UP */
+		drive-strength = <4>; /* 4 MA */
+	};
+};
+
+&cci1_suspend {
+	config {
+		pins = "gpio112", "gpio113";
+		bias-pull-down; /* PULL DOWN */
+		drive-strength = <4>; /* 4 MA */
+	};
+};
+
+&cam_csiphy2 {
+	compatible = "qcom,csiphy-v2.1.3-m16t", "qcom,csiphy";
+};
+
+&cam_csiphy3 {
+	compatible = "qcom,csiphy-v2.1.3-m16t", "qcom,csiphy";
+};
+
+&tlmm {
+	cam_sensor_mclk0_active: cam_sensor_mclk0_active {
+		/* MCLK0 */
+		mux {
+			pins = "gpio100";
+			function = "cam_mclk";
+		};
+
+		config {
+			pins = "gpio100";
+			bias-disable; /* No PULL */
+			drive-strength = <4>; /* 4 MA */
+		};
+	};
+
+	cam_sensor_mclk0_suspend: cam_sensor_mclk0_suspend {
+		/* MCLK0 */
+		mux {
+			pins = "gpio100";
+			function = "cam_mclk";
+		};
+
+		config {
+			pins = "gpio100";
+			bias-pull-down; /* PULL DOWN */
+			drive-strength = <4>; /* 4 MA */
+		};
+	};
+
+	cam_sensor_mclk1_active: cam_sensor_mclk1_active {
+		/* MCLK1 */
+		mux {
+			pins = "gpio101";
+			function = "cam_mclk";
+		};
+
+		config {
+			pins = "gpio101";
+			bias-disable; /* No PULL */
+			drive-strength = <4>; /* 4 MA */
+		};
+	};
+
+	cam_sensor_mclk1_suspend: cam_sensor_mclk1_suspend {
+		/* MCLK1 */
+		mux {
+			pins = "gpio101";
+			function = "cam_mclk";
+		};
+
+		config {
+			pins = "gpio101";
+			bias-pull-down; /* PULL DOWN */
+			drive-strength = <4>; /* 4 MA */
+		};
+	};
+
+	cam_sensor_mclk2_active: cam_sensor_mclk2_active {
+		/* MCLK2 */
+		mux {
+			pins = "gpio102";
+			function = "cam_mclk";
+		};
+
+		config {
+			pins = "gpio102";
+			bias-disable; /* No PULL */
+			drive-strength = <4>; /* 4 MA */
+		};
+	};
+
+	cam_sensor_mclk2_suspend: cam_sensor_mclk2_suspend {
+		/* MCLK2 */
+		mux {
+			pins = "gpio102";
+			function = "cam_mclk";
+		};
+
+		config {
+			pins = "gpio102";
+			bias-pull-down; /* PULL DOWN */
+			drive-strength = <4>; /* 4 MA */
+		};
+	};
+
+	cam_sensor_mclk5_active: cam_sensor_mclk5_active {
+		/* MCLK5 */
+		mux {
+			pins = "gpio105";
+			function = "cam_mclk";
+		};
+
+		config {
+			pins = "gpio105";
+			bias-disable; /* No PULL */
+			drive-strength = <4>; /* 4 MA */
+		};
+	};
+
+	cam_sensor_mclk5_suspend: cam_sensor_mclk5_suspend {
+		/* MCLK5 */
+		mux {
+			pins = "gpio105";
+			function = "cam_mclk";
+		};
+
+		config {
+			pins = "gpio105";
+			bias-pull-down; /* PULL DOWN */
+			drive-strength = <4>; /* 4 MA */
+		};
+	};
+
+	cam_sensor_w_avdd1_active: cam_sensor_w_avdd1_active {
+		/* SENSOR WIDE AVDD ENABLE */
+		mux {
+			function = "gpio";
+			pins = "gpio64";
+		};
+
+		config {
+			pins = "gpio64";
+			bias-disable; /* No PULL */
+			drive-strength = <2>; /* 2 MA */
+		};
+	};
+
+	cam_sensor_w_avdd1_suspend: cam_sensor_w_avdd1_suspend {
+		/* SENSOR WIDE AVDD DISABLE */
+		mux {
+			function = "gpio";
+			pins = "gpio64";
+		};
+
+		config {
+			pins = "gpio64";
+			bias-pull-down; /* PULL DOWN */
+			drive-strength = <2>; /* 2 MA */
+			output-low;
+		};
+	};
+
+	cam_sensor_w_dvdd_active: cam_sensor_w_dvdd_active {
+		/* SENSOR WIDE DVDD ENABLE */
+		mux {
+			function = "gpio";
+			pins = "gpio2";
+		};
+
+		config {
+			pins = "gpio2";
+			bias-disable; /* No PULL */
+			drive-strength = <2>; /* 2 MA */
+		};
+	};
+
+	cam_sensor_w_dvdd_suspend: cam_sensor_w_dvdd_suspend {
+		/* SENSOR WIDE DVDD DISABLE */
+		mux {
+			function = "gpio";
+			pins = "gpio2";
+		};
+
+		config {
+			pins = "gpio2";
+			bias-pull-down; /* PULL DOWN */
+			drive-strength = <2>; /* 2 MA */
+			output-low;
+		};
+	};
+
+	cam_sensor_active_rst0: cam_sensor_active_rst0 {
+		/* RESET REAR */
+		mux {
+			function = "gpio";
+			pins = "gpio126";
+		};
+
+		config {
+			pins = "gpio126";
+			bias-disable; /* No PULL */
+			drive-strength = <2>; /* 2 MA */
+		};
+	};
+
+	cam_sensor_suspend_rst0: cam_sensor_suspend_rst0 {
+		/* RESET REAR */
+		mux {
+			pins = "gpio126";
+			function = "gpio";
+		};
+
+		config {
+			pins = "gpio126";
+			bias-pull-down; /* PULL DOWN */
+			drive-strength = <2>; /* 2 MA */
+			output-low;
+		};
+	};
+
+	cam_sensor_active_rst1: cam_sensor_active_rst1 {
+		/* RESET REARAUX */
+		mux {
+			function = "gpio";
+			pins = "gpio127";
+		};
+
+		config {
+			pins = "gpio127";
+			bias-disable; /* No PULL */
+			drive-strength = <2>; /* 2 MA */
+		};
+	};
+
+	cam_sensor_suspend_rst1: cam_sensor_suspend_rst1 {
+		/* RESET REARAUX */
+		mux {
+			function = "gpio";
+			pins = "gpio127";
+		};
+
+		config {
+			pins = "gpio127";
+			bias-pull-down; /* PULL DOWN */
+			drive-strength = <2>; /* 2 MA */
+			output-low;
+		};
+	};
+
+	cam_sensor_u_avdd_active: cam_sensor_u_avdd_active {
+		/* SENSOR ULTRA AVDD ENABLE */
+		mux {
+			function = "gpio";
+			pins = "gpio62";
+		};
+
+		config {
+			pins = "gpio62";
+			bias-disable; /* No PULL */
+			drive-strength = <2>; /* 2 MA */
+		};
+	};
+
+	cam_sensor_u_avdd_suspend: cam_sensor_u_avdd_suspend {
+		/* SENSOR ULTRA AVDD DISABLE */
+		mux {
+			function = "gpio";
+			pins = "gpio62";
+		};
+
+		config {
+			pins = "gpio62";
+			bias-pull-down; /* PULL DOWN */
+			drive-strength = <2>; /* 2 MA */
+			output-low;
+		};
+	};
+
+	cam_sensor_u_dvdd_active: cam_sensor_u_dvdd_active {
+		/* SENSOR ULTRA DVDD DISABLE */
+		mux {
+			function = "gpio";
+			pins = "gpio69";
+		};
+
+		config {
+			pins = "gpio69";
+			bias-disable; /* No PULL */
+			drive-strength = <2>; /* 2 MA */
+		};
+	};
+
+	cam_sensor_u_dvdd_suspend: cam_sensor_u_dvdd_suspend {
+		/* SENSOR ULTRA DVDD DISABLE */
+		mux {
+			function = "gpio";
+			pins = "gpio69";
+		};
+
+		config {
+			pins = "gpio69";
+			bias-pull-down; /* PULL DOWN */
+			drive-strength = <2>; /* 2 MA */
+			output-low;
+		};
+	};
+
+	cam_sensor_active_rst2: cam_sensor_active_rst2 {
+		/* RESET 2 */
+		mux {
+			function = "gpio";
+			pins = "gpio24";
+		};
+
+		config {
+			pins = "gpio24";
+			bias-disable; /* No PULL */
+			drive-strength = <2>; /* 2 MA */
+		};
+	};
+
+	cam_sensor_suspend_rst2: cam_sensor_suspend_rst2 {
+		/* RESET 2 */
+		mux {
+			function = "gpio";
+			pins = "gpio24";
+		};
+
+		config {
+			pins = "gpio24";
+			bias-pull-down; /* PULL DOWN */
+			drive-strength = <2>; /* 2 MA */
+			output-low;
+		};
+	};
+
+	cam_sensor_m_avdd_active: cam_sensor_m_avdd_active {
+		/* SENSOR MACRO AVDD ENABLE */
+		mux {
+			function = "gpio";
+			pins = "gpio61";
+		};
+
+		config {
+			pins = "gpio61";
+			bias-disable; /* No PULL */
+			drive-strength = <2>; /* 2 MA */
+		};
+	};
+
+	cam_sensor_m_avdd_suspend: cam_sensor_m_avdd_suspend {
+		/* SENSOR MACRO AVDD DISABLE */
+		mux {
+			function = "gpio";
+			pins = "gpio61";
+		};
+
+		config {
+			pins = "gpio61";
+			bias-pull-down; /* PULL DOWN */
+			drive-strength = <2>; /* 2 MA */
+			output-low;
+		};
+	};
+
+	cam_sensor_active_rst3: cam_sensor_active_rst3 {
+		/* RESET 3 */
+		mux {
+			function = "gpio";
+			pins = "gpio128";
+		};
+
+		config {
+			pins = "gpio128";
+			bias-disable; /* No PULL */
+			drive-strength = <2>; /* 2 MA */
+		};
+	};
+
+	cam_sensor_suspend_rst3: cam_sensor_suspend_rst3 {
+		/* RESET 3 */
+		mux {
+			function = "gpio";
+			pins = "gpio128";
+		};
+
+		config {
+			pins = "gpio128";
+			bias-pull-down; /* PULL DOWN */
+			drive-strength = <2>; /* 2 MA */
+			output-low;
+		};
+	};
+
+	cam_sensor_active_rst4: cam_sensor_active_rst4 {
+		/* RESET 4 */
+		mux {
+			function = "gpio";
+			pins = "gpio80";
+		};
+
+		config {
+			pins = "gpio80";
+			bias-disable; /* No PULL */
+			drive-strength = <2>; /* 2 MA */
+		};
+	};
+
+	cam_sensor_suspend_rst4: cam_sensor_suspend_rst4 {
+		/* RESET 4 */
+		mux {
+			function = "gpio";
+			pins = "gpio80";
+		};
+
+		config {
+			pins = "gpio80";
+			bias-pull-down; /* PULL DOWN */
+			drive-strength = <2>; /* 2 MA */
+			output-low;
+		};
+	};
+
+	cam_soft_led_en_active: cam_soft_led_en_active {
+		/* LED ENABLE */
+		mux {
+			function = "gpio";
+			pins = "gpio15";
+		};
+
+		config {
+			pins = "gpio15";
+			bias-disable; /* No PULL */
+			drive-strength = <2>; /* 2 MA */
+		};
+	};
+
+	cam_soft_led_en_suspend: cam_soft_led_en_suspend {
+		/* LED DISABLE */
+		mux {
+			function = "gpio";
+			pins = "gpio15";
+		};
+
+		config {
+			pins = "gpio15";
+			bias-pull-down; /* PULL DOWN */
+			drive-strength = <2>; /* 2 MA */
+			output-low;
+		};
+	};
+};
+
+&soc {
+	CAMERA_W_DVDD: gpio-regulator@0 {
+		compatible = "regulator-fixed";
+		reg = <0x00 0x00>;
+		regulator-name = "CAMERA_W_DVDD";
+		regulator-min-microvolt = <1100000>;
+		regulator-max-microvolt = <1100000>;
+		regulator-enable-ramp-delay = <100>;
+		enable-active-high;
+		gpio = <&tlmm 2 GPIO_ACTIVE_HIGH>;
+		pinctrl-names = "default", "sleep";
+		pinctrl-0 = <&cam_sensor_w_dvdd_active
+					&cam_sensor_w_dvdd_suspend>;
+		vin-supply = <&S12B>;
+	};
+
+	CAMERA_W_AVDD: gpio-regulator@1 {
+		compatible = "regulator-fixed";
+		reg = <0x01 0x00>;
+		regulator-name = "CAMERA_W_AVDD";
+		regulator-min-microvolt = <2800000>;
+		regulator-max-microvolt = <2800000>;
+		regulator-enable-ramp-delay = <100>;
+		enable-active-high;
+		gpio = <&tlmm 64 GPIO_ACTIVE_HIGH>;
+		pinctrl-names = "default", "sleep";
+		pinctrl-0 = <&cam_sensor_w_avdd1_active
+					&cam_sensor_w_avdd1_suspend>;
+		vin-supply = <&BOB>;
+	};
+
+	led_flash_triple_wide: qcom,camera-flash@1 {
+		cell-index = <1>;
+		compatible = "qcom,camera-flash";
+		flash-source = <&pm8350c_flash0 &pm8350c_flash3>;
+		switch-source = <&pm8350c_switch0>;
+		torch-source = <&pm8350c_torch0 &pm8350c_torch3>;
+		status = "ok";
+	};
+
+	led_flash_triple_ultra: qcom,camera-flash@2 {
+		cell-index = <2>;
+		compatible = "qcom,camera-flash";
+		flash-source = <&pm8350c_flash0 &pm8350c_flash3>;
+		switch-source = <&pm8350c_switch0>;
+		torch-source = <&pm8350c_torch0 &pm8350c_torch3>;
+		status = "ok";
+	};
+
+	led_flash_triple_macro: qcom,camera-flash@3 {
+		cell-index = <3>;
+		compatible = "qcom,camera-flash";
+		flash-source = <&pm8350c_flash0 &pm8350c_flash3>;
+		switch-source = <&pm8350c_switch0>;
+		torch-source = <&pm8350c_torch0 &pm8350c_torch3>;
+		status = "ok";
+	};
+
+	qcom,cam-res-mgr {
+		status = "ok";
+		compatible = "qcom,cam-res-mgr";
+	};
+};
+
+&cam_cci0 {
+	actuator_triple_wide: qcom,actuator0 {
+		cell-index = <0>;
+		compatible = "qcom,actuator";
+		cci-master = <CCI_MASTER_1>;
+		cam_vaf-supply = <&L6J>;
+		regulator-names = "cam_vaf";
+		rgltr-cntrl-support;
+		rgltr-min-voltage = <2800000>;
+		rgltr-max-voltage = <2800000>;
+		rgltr-load-current = <300000>;
+		status = "ok";
+	};
+
+	eeprom_triple_wide: qcom,eeprom0 {
+		cell-index = <0>;
+		compatible = "qcom,eeprom";
+		cam_vio-supply = <&L4H>;
+		cam_vdig-supply = <&CAMERA_W_DVDD>;
+		cam_clk-supply = <&cam_cc_titan_top_gdsc>;
+		cam_vana-supply = <&CAMERA_W_AVDD>;
+		cam_vaf-supply = <&L6J>;
+		regulator-names = "cam_vio", "cam_vana",
+			"cam_vdig", "cam_vaf", "cam_clk";
+		rgltr-cntrl-support;
+		rgltr-min-voltage = <1800000 2800000 1100000 2800000 0>;
+		rgltr-max-voltage = <1800000 2800000 1100000 2800000 0>;
+		rgltr-load-current = <3500 164100 1251000 300000 0>;
+		gpio-no-mux = <0>;
+		pinctrl-names = "cam_default", "cam_suspend";
+		pinctrl-0 = <&cam_sensor_mclk2_active
+					&cam_sensor_active_rst0>;
+		pinctrl-1 = <&cam_sensor_mclk2_suspend
+					&cam_sensor_suspend_rst0>;
+		gpios = <&tlmm 102 GPIO_ACTIVE_HIGH>,
+			<&tlmm 126 GPIO_ACTIVE_HIGH>;
+		gpio-reset = <1>;
+		gpio-req-tbl-num = <0 1>;
+		gpio-req-tbl-flags = <1 0>;
+		gpio-req-tbl-label = "CAMIF_MCLK2",
+					"CAM_RESET0";
+		cci-master = <CCI_MASTER_1>;
+		clocks = <&clock_camcc CAM_CC_MCLK2_CLK>;
+		clock-names = "cam_clk";
+		clock-cntl-level = "nominal";
+		clock-rates = <19200000>;
+		status = "ok";
+	};
+
+	eeprom_triple_front: qcom,eeprom1 {
+		cell-index = <1>;
+		compatible = "qcom,eeprom";
+		cam_vio-supply = <&L4H>;
+		cam_vdig-supply = <&L1J>;
+		cam_clk-supply = <&cam_cc_titan_top_gdsc>;
+		cam_vana-supply = <&L7J>;
+		regulator-names = "cam_vio", "cam_vana",
+			"cam_vdig", "cam_clk";
+		rgltr-cntrl-support;
+		rgltr-min-voltage = <1800000 2800000 1000000 0>;
+		rgltr-max-voltage = <1800000 2800000 1000000 0>;
+		rgltr-load-current = <3500 164100 5000 0>;
+		gpio-no-mux = <0>;
+		pinctrl-names = "cam_default", "cam_suspend";
+		pinctrl-0 = <&cam_sensor_mclk5_active
+					&cam_sensor_active_rst1>;
+		pinctrl-1 = <&cam_sensor_mclk5_suspend
+					&cam_sensor_suspend_rst1>;
+		gpios = <&tlmm 105 GPIO_ACTIVE_HIGH>,
+			<&tlmm 127 GPIO_ACTIVE_HIGH>;
+		gpio-reset = <1>;
+		gpio-req-tbl-num = <0 1>;
+		gpio-req-tbl-flags = <1 0>;
+		gpio-req-tbl-label = "CAMIF_MCLK5",
+					"CAM_RESET1";
+		cci-master = <CCI_MASTER_0>;
+		clocks = <&clock_camcc CAM_CC_MCLK5_CLK>;
+		clock-names = "cam_clk";
+		clock-cntl-level = "nominal";
+		clock-rates = <19200000>;
+		status = "ok";
+	};
+
+	eeprom_triple_ultra: qcom,eeprom2 {
+		cell-index = <2>;
+		compatible = "qcom,eeprom";
+		cam_vio-supply = <&L4H>;
+		cam_vdig-supply = <&L2J>;
+		cam_clk-supply = <&cam_cc_titan_top_gdsc>;
+		cam_vana-supply = <&L3J>;
+		regulator-names = "cam_vio", "cam_vana",
+			"cam_vdig", "cam_clk";
+		rgltr-cntrl-support;
+		rgltr-min-voltage = <1800000 2800000 1200000 0>;
+		rgltr-max-voltage = <1800000 2800000 1200000 0>;
+		rgltr-load-current = <3500 164100 1251000 0>;
+		gpio-no-mux = <0>;
+		pinctrl-names = "cam_default", "cam_suspend";
+		pinctrl-0 = <&cam_sensor_mclk1_active
+					&cam_sensor_active_rst2>;
+		pinctrl-1 = <&cam_sensor_mclk1_suspend
+					&cam_sensor_suspend_rst2>;
+		gpios = <&tlmm 101 GPIO_ACTIVE_HIGH>,
+			<&tlmm 24 GPIO_ACTIVE_HIGH>;
+		gpio-reset = <1>;
+		gpio-req-tbl-num = <0 1>;
+		gpio-req-tbl-flags = <1 0>;
+		gpio-req-tbl-label = "CAMIF_MCLK1",
+					"CAM_RESET2";
+		cci-master = <CCI_MASTER_0>;
+		clocks = <&clock_camcc CAM_CC_MCLK1_CLK>;
+		clock-names = "cam_clk";
+		clock-cntl-level = "nominal";
+		clock-rates = <19200000>;
+		status = "ok";
+	};
+
+	qcom,cam-sensor0 {
+		cell-index = <0>;
+		compatible = "qcom,cam-sensor";
+		csiphy-sd-index = <2>;
+		sensor-position-roll = <90>;
+		sensor-position-pitch = <0>;
+		sensor-position-yaw = <180>;
+		eeprom-src = <&eeprom_triple_wide>;
+		actuator-src = <&actuator_triple_wide>;
+		led-flash-src = <&led_flash_triple_wide>;
+		cam_vaf-supply = <&L6J>;
+		cam_vana-supply = <&CAMERA_W_AVDD>;
+		cam_clk-supply = <&cam_cc_titan_top_gdsc>;
+		cam_vdig-supply = <&CAMERA_W_DVDD>;
+		cam_vio-supply = <&L4H>;
+		regulator-names = "cam_vio", "cam_vana",
+			"cam_vdig", "cam_vaf", "cam_clk";
+		rgltr-cntrl-support;
+		rgltr-min-voltage = <1800000 2800000 1100000 2800000 0>;
+		rgltr-max-voltage = <1800000 2800000 1100000 2800000 0>;
+		rgltr-load-current = <3500 0x28104 164100 300000 0>;
+		gpio-no-mux = <0>;
+		pinctrl-names = "cam_default", "cam_suspend";
+		pinctrl-0 = <&cam_sensor_mclk2_active
+					&cam_sensor_active_rst0>;
+		pinctrl-1 = <&cam_sensor_mclk2_suspend
+					&cam_sensor_suspend_rst0>;
+		gpios = <&tlmm 102 GPIO_ACTIVE_HIGH>,
+			<&tlmm 126 GPIO_ACTIVE_HIGH>;
+		gpio-reset = <1>;
+		gpio-req-tbl-num = <0 1>;
+		gpio-req-tbl-flags = <1 0>;
+		gpio-req-tbl-label = "CAMIF_MCLK2",
+					"CAM_RESET0";
+		cci-master = <CCI_MASTER_1>;
+		clocks = <&clock_camcc CAM_CC_MCLK2_CLK>;
+		clock-names = "cam_clk";
+		clock-cntl-level = "nominal";
+		clock-rates = <19200000>;
+		status = "ok";
+	};
+
+	qcom,cam-sensor1 {
+		cell-index = <1>;
+		compatible = "qcom,cam-sensor";
+		csiphy-sd-index = <3>;
+		sensor-position-roll = <270>;
+		sensor-position-pitch = <0>;
+		sensor-position-yaw = <0>;
+		eeprom-src = <&eeprom_triple_front>;
+		cam_vio-supply = <&L4H>;
+		cam_vdig-supply = <&L1J>;
+		cam_clk-supply = <&cam_cc_titan_top_gdsc>;
+		cam_vana-supply = <&L7J>;
+		regulator-names = "cam_vio", "cam_vana",
+			"cam_vdig", "cam_clk";
+		rgltr-cntrl-support;
+		rgltr-min-voltage = <1800000 2800000 1000000 0>;
+		rgltr-max-voltage = <1800000 2800000 1000000 0>;
+		rgltr-load-current = <3500 164100 5000 0>;
+		gpio-no-mux = <0>;
+		pinctrl-names = "cam_default", "cam_suspend";
+		pinctrl-0 = <&cam_sensor_mclk5_active
+					&cam_sensor_active_rst1>;
+		pinctrl-1 = <&cam_sensor_mclk5_suspend
+					&cam_sensor_suspend_rst1>;
+		gpios = <&tlmm 105 GPIO_ACTIVE_HIGH>,
+			<&tlmm 127 GPIO_ACTIVE_HIGH>;
+		gpio-reset = <1>;
+		gpio-req-tbl-num = <0 1>;
+		gpio-req-tbl-flags = <1 0>;
+		gpio-req-tbl-label = "CAMIF_MCLK5",
+					"CAM_RESET1";
+		cci-master = <CCI_MASTER_0>;
+		clocks = <&clock_camcc CAM_CC_MCLK5_CLK>;
+		clock-names = "cam_clk";
+		clock-cntl-level = "nominal";
+		clock-rates = <19200000>;
+		status = "ok";
+	};
+
+	qcom,cam-sensor2 {
+		cell-index = <2>;
+		compatible = "qcom,cam-sensor";
+		csiphy-sd-index = <0>;
+		sensor-position-roll = <90>;
+		sensor-position-pitch = <0>;
+		sensor-position-yaw = <180>;
+		eeprom-src = <&eeprom_triple_ultra>;
+		led-flash-src = <&led_flash_triple_ultra>;
+		cam_vio-supply = <&L4H>;
+		cam_vdig-supply = <&L2J>;
+		cam_clk-supply = <&cam_cc_titan_top_gdsc>;
+		cam_vana-supply = <&L3J>;
+		regulator-names = "cam_vio", "cam_vana",
+			"cam_vdig", "cam_clk";
+		rgltr-cntrl-support;
+		rgltr-min-voltage = <1800000 2800000 1200000 0>;
+		rgltr-max-voltage = <1800000 2800000 1200000 0>;
+		rgltr-load-current = <3500 164100 1251000 0>;
+		gpio-no-mux = <0>;
+		pinctrl-names = "cam_default", "cam_suspend";
+		pinctrl-0 = <&cam_sensor_mclk1_active
+					&cam_sensor_active_rst2>;
+		pinctrl-1 = <&cam_sensor_mclk1_suspend
+					&cam_sensor_suspend_rst2>;
+		gpios = <&tlmm 101 GPIO_ACTIVE_HIGH>,
+			<&tlmm 24 GPIO_ACTIVE_HIGH>;
+		gpio-reset = <1>;
+		gpio-req-tbl-num = <0 1>;
+		gpio-req-tbl-flags = <1 0>;
+		gpio-req-tbl-label = "CAMIF_MCLK1",
+					"CAM_RESET2";
+		cci-master = <CCI_MASTER_0>;
+		clocks = <&clock_camcc CAM_CC_MCLK1_CLK>;
+		clock-names = "cam_clk";
+		clock-cntl-level = "nominal";
+		clock-rates = <19200000>;
+		status = "ok";
+	};
+};
+
+&cam_cci1 {
+	eeprom_triple_macro: qcom,eeprom3 {
+		cell-index = <3>;
+		compatible = "qcom,eeprom";
+		cam_vio-supply = <&L5J>;
+		cam_vana-supply = <&L4J>;
+		cam_clk-supply = <&cam_cc_titan_top_gdsc>;
+		regulator-names = "cam_vio", "cam_vana",
+			"cam_clk";
+		rgltr-cntrl-support;
+		rgltr-min-voltage = <1800000 2800000 0>;
+		rgltr-max-voltage = <1800000 2800000 0>;
+		rgltr-load-current = <3500 164100 0>;
+		gpio-no-mux = <0>;
+		pinctrl-names = "cam_default", "cam_suspend";
+		pinctrl-0 = <&cam_sensor_mclk0_active
+					&cam_sensor_active_rst3>;
+		pinctrl-1 = <&cam_sensor_mclk0_suspend
+					&cam_sensor_suspend_rst3>;
+		gpios = <&tlmm 100 GPIO_ACTIVE_HIGH>,
+			<&tlmm 128 GPIO_ACTIVE_HIGH>;
+		gpio-reset = <1>;
+		gpio-req-tbl-num = <0 1>;
+		gpio-req-tbl-flags = <1 0>;
+		gpio-req-tbl-label = "CAMIF_MCLK0",
+					"CAM_RESET3";
+		cci-master = <CCI_MASTER_0>;
+		clocks = <&clock_camcc CAM_CC_MCLK0_CLK>;
+		clock-names = "cam_clk";
+		clock-cntl-level = "nominal";
+		clock-rates = <19200000>;
+		status = "ok";
+	};
+
+	qcom,cam-sensor3 {
+		cell-index = <3>;
+		compatible = "qcom,cam-sensor";
+		csiphy-sd-index = <1>;
+		sensor-position-roll = <90>;
+		sensor-position-pitch = <0>;
+		sensor-position-yaw = <180>;
+		eeprom-src = <&eeprom_triple_macro>;
+		led-flash-src = <&led_flash_triple_macro>;
+		cam_vio-supply = <&L5J>;
+		cam_vana-supply = <&L4J>;
+		cam_clk-supply = <&cam_cc_titan_top_gdsc>;
+		regulator-names = "cam_vio", "cam_vana",
+			"cam_clk";
+		rgltr-cntrl-support;
+		rgltr-min-voltage = <1800000 2800000 0>;
+		rgltr-max-voltage = <1800000 2800000 0>;
+		rgltr-load-current = <3500 164100 0>;
+		gpio-no-mux = <0>;
+		pinctrl-names = "cam_default", "cam_suspend";
+		pinctrl-0 = <&cam_sensor_mclk0_active
+					&cam_sensor_active_rst3>;
+		pinctrl-1 = <&cam_sensor_mclk0_suspend
+					&cam_sensor_suspend_rst3>;
+		gpios = <&tlmm 100 GPIO_ACTIVE_HIGH>,
+			<&tlmm 128 GPIO_ACTIVE_HIGH>;
+		gpio-reset = <1>;
+		gpio-req-tbl-num = <0 1>;
+		gpio-req-tbl-flags = <1 0>;
+		gpio-req-tbl-label = "CAMIF_MCLK0",
+					"CAM_RESET3";
+		cci-master = <CCI_MASTER_0>;
+		clocks = <&clock_camcc CAM_CC_MCLK0_CLK>;
+		clock-names = "cam_clk";
+		clock-cntl-level = "nominal";
+		clock-rates = <19200000>;
+		status = "ok";
+	};
+};

--- a/qcom/display/Kbuild
+++ b/qcom/display/Kbuild
@@ -41,6 +41,7 @@ dtbo-$(CONFIG_ARCH_CAPE) += display/cape-sde.dtbo \
 		display/cape-sde-display-qrd-overlay.dtbo \
 		display/thor-sde-display-cape-mtp-overlay.dtbo \
 		display/unicorn-sde-display-mtp-overlay.dtbo \
+		display/marble-sde-display-mtp-overlay.dtbo \
 		display/mondrian-sde-display-mtp-overlay.dtbo \
 		display/mayfly-sde-display-mtp-overlay.dtbo
 else

--- a/qcom/display/display/dsi-panel-m16t-36-02-0a-dsc-vid.dtsi
+++ b/qcom/display/display/dsi-panel-m16t-36-02-0a-dsc-vid.dtsi
@@ -40,7 +40,7 @@
 		qcom,mdss-dsi-pan-enable-dynamic-fps;
 		qcom,mdss-dsi-pan-fps-update =
 			"dfps_immediate_porch_mode_vfp";
-		qcom,dsi-supported-dfps-list = <60 120 90 30>;
+		qcom,dsi-supported-dfps-list = <60 120 90>;
 
 		qcom,mdss-dsi-display-timings {
 			timing@0{

--- a/qcom/display/display/dsi-panel-m16t-36-0d-0b-dsc-vid.dtsi
+++ b/qcom/display/display/dsi-panel-m16t-36-0d-0b-dsc-vid.dtsi
@@ -197,15 +197,15 @@ qcom,mdss-dsi-display-timings {
 			];
 			qcom,mdss-dsi-nolp-command-state = "dsi_hs_mode";
 			mi,mdss-dsi-fps-120-gamma-command = [
-				39 00 00 00 00 00 02 6C 02
+				39 00 00 10 00 00 02 6C 02
 			];
 			mi,mdss-dsi-fps-120-gamma-command-state = "dsi_hs_mode";
 			mi,mdss-dsi-fps-90-gamma-command = [
-				39 00 00 00 00 00 02 6C 01
+				39 00 00 10 00 00 02 6C 01
 			];
 			mi,mdss-dsi-fps-90-gamma-command-state = "dsi_hs_mode";
 			mi,mdss-dsi-fps-60-gamma-command = [
-				39 00 00 00 00 00 02 6C 00
+				39 00 00 10 00 00 02 6C 00
 			];
 			mi,mdss-dsi-fps-60-gamma-command-state = "dsi_hs_mode";
 		};

--- a/qcom/display/display/dsi-panel-m16t-36-0d-0b-dsc-vid.dtsi
+++ b/qcom/display/display/dsi-panel-m16t-36-0d-0b-dsc-vid.dtsi
@@ -35,7 +35,7 @@
 		qcom,mdss-dsi-pan-enable-dynamic-fps;
 		qcom,mdss-dsi-pan-fps-update =
 			"dfps_immediate_porch_mode_vfp";
-		qcom,dsi-supported-dfps-list = <60 120 90 30>;
+		qcom,dsi-supported-dfps-list = <60 120 90>;
 qcom,mdss-dsi-display-timings {
 			timing@0{
 				qcom,mdss-dsi-video-mode;

--- a/qcom/display/display/marble-sde-display-mtp-overlay.dts
+++ b/qcom/display/display/marble-sde-display-mtp-overlay.dts
@@ -1,0 +1,12 @@
+/dts-v1/;
+/plugin/;
+
+#include "marble-sde-display-mtp.dtsi"
+
+/ {
+	model = "Qualcomm Technologies, Inc. 7475 marble";
+	compatible = "qcom,cape-mtp", "qcom,cape", "qcom,mtp";
+	qcom,msm-id = <530 0x10000>, <531 0x10000>, <540 0x10000>, <591 0x10000>;
+	qcom,board-id = <0x10008 0>;
+	xiaomi,miboard-id = <0xF 0>;
+};

--- a/qcom/display/display/marble-sde-display-mtp.dtsi
+++ b/qcom/display/display/marble-sde-display-mtp.dtsi
@@ -1,0 +1,86 @@
+#include "cape-sde-display.dtsi"
+
+&dsi_m16t_36_02_0a_dsc_vid {
+	qcom,panel-supply-entries = <&dsi_panel_pwr_supply_m16t>;
+	qcom,mdss-dsi-bl-pmic-control-type = "bl_ctrl_dcs";
+	qcom,mdss-dsi-bl-min-level = <4>;
+	qcom,mdss-dsi-bl-max-level = <4095>;
+	qcom,mdss-brightness-max-level = <4095>;
+	qcom,mdss-brightness-init-level = <307>;
+	qcom,mdss-dsi-bl-inverted-dbv;
+	qcom,platform-reset-gpio = <&tlmm 0 0>;
+};
+
+&dsi_m16t_36_0d_0b_dsc_vid {
+	qcom,panel-supply-entries = <&dsi_panel_pwr_supply_0b_m16t>;
+	qcom,mdss-dsi-bl-pmic-control-type = "bl_ctrl_dcs";
+	qcom,mdss-dsi-bl-min-level = <4>;
+	qcom,mdss-dsi-bl-max-level = <4095>;
+	qcom,mdss-brightness-max-level = <4095>;
+	qcom,mdss-brightness-init-level = <307>;
+	qcom,mdss-dsi-bl-inverted-dbv;
+	qcom,platform-reset-gpio = <&tlmm 0 0>;
+};
+
+&L1D {
+    regulator-max-microvolt = <1250000>;
+};
+
+&dsi_r66451_amoled_video {
+	qcom,panel-supply-entries = <&dsi_panel_pwr_supply_m16t>;
+	qcom,mdss-dsi-bl-pmic-control-type = "bl_ctrl_dcs";
+	qcom,mdss-dsi-bl-min-level = <1>;
+	qcom,mdss-dsi-bl-max-level = <4095>;
+	qcom,mdss-brightness-max-level = <255>;
+	qcom,mdss-dsi-bl-inverted-dbv;
+	qcom,platform-reset-gpio = <&tlmm 0 0>;
+};
+
+&sde_dsi {
+	qcom,dsi-default-panel = <&dsi_r66451_amoled_video>;
+	vddio-supply = <&L12C>;
+	vddd-supply = <&L1D>;
+	vci-supply = <&L13C>;
+};
+
+&mdss_dsi0 {
+	mi,support-max-hs-timer;
+};
+
+&qupv3_se4_spi {
+	m16t-touch@0 {
+		panel = <&dsi_m16t_36_02_0a_dsc_vid &dsi_m16t_36_0d_0b_dsc_vid
+			&dsi_r66451_amoled_video>;
+	};
+};
+
+&soc {
+	thermal-message {
+		board-sensor = "VIRTUAL-SENSOR0";
+	};
+	thermal_screen: thermal-screen {
+		panel = <&dsi_m16t_36_02_0a_dsc_vid &dsi_m16t_36_0d_0b_dsc_vid
+		&dsi_r66451_amoled_video>;
+	};
+	charge_screen: charge-screen {
+		panel = <&dsi_m16t_36_02_0a_dsc_vid &dsi_m16t_36_0d_0b_dsc_vid
+		&dsi_r66451_amoled_video>;
+	};
+	fingerprint_screen: fingerprint-screen {
+		panel = <&dsi_m16t_36_02_0a_dsc_vid &dsi_m16t_36_0d_0b_dsc_vid
+		&dsi_r66451_amoled_video>;
+	};
+};
+
+&spmi_bus {
+	qcom,pm8350b@3 {
+		qcom,amoled-ecm@f900 {
+			display-panels = <&dsi_m16t_36_02_0a_dsc_vid &dsi_m16t_36_0d_0b_dsc_vid
+			&dsi_r66451_amoled_video>;
+		};
+	};
+};
+
+&mdss_mdp {
+        connectors = <&sde_dsi &smmu_sde_unsec &smmu_sde_sec &sde_wb &sde_rscc>;
+};

--- a/qcom/marble-pinctrl.dtsi
+++ b/qcom/marble-pinctrl.dtsi
@@ -1,0 +1,79 @@
+/*for marble pinctrl */
+&tlmm {
+    /* TOP Smart PA */
+	aw882xx_reset_active_top:aw882xx_reset_active_top {
+		/* active state */
+		mux {
+			pins = "gpio1";
+			function = "gpio";
+		};
+
+		config {
+			pins = "gpio1";
+			drive-strength = <2>;
+			bias-pull-down;
+			output-high;
+		};
+	};
+
+	aw882xx_reset_suspend_top:aw882xx_reset_suspend_top {
+		/* sleep state */
+		mux {
+			pins = "gpio1";
+			function = "gpio";
+		};
+
+		config {
+			pins = "gpio1";
+			drive-strength = <2>;
+			bias-pull-down;
+			output-low;
+		};
+	};
+
+	/* TOP Smart PA INT*/
+	aw882xx_irq_active_top:aw882xx_irq_active_top {
+		mux {
+			pins = "gpio88";
+			function = "gpio";
+		};
+
+		config {
+			pins = "gpio88";
+			drive-strength = <2>;
+			bias-disable;
+			input-enable;
+		};
+	};
+
+	/* BOT Smart PA */
+	aw882xx_reset_active_bot:aw882xx_reset_active_bot {
+		/* active state */
+		mux {
+			pins = "gpio120";
+			function = "gpio";
+		};
+
+		config {
+			pins = "gpio120";
+			drive-strength = <2>;
+			bias-pull-down;
+			output-high;
+		};
+	};
+
+	aw882xx_reset_suspend_bot:aw882xx_reset_suspend_bot {
+		/* sleep state */
+		mux {
+			pins = "gpio120";
+			function = "gpio";
+		};
+
+		config {
+			pins = "gpio120";
+			drive-strength = <2>;
+			bias-pull-down;
+			output-low;
+		};
+	};
+};

--- a/qcom/marble-sm7475-pm8008-overlay.dts
+++ b/qcom/marble-sm7475-pm8008-overlay.dts
@@ -1,0 +1,13 @@
+/dts-v1/;
+/plugin/;
+
+#include "marble-sm7475.dtsi"
+#include "waipio-pm8008.dtsi"
+
+/ {
+	model = "Marble based on Qualcomm Technologies, Inc SM7475";
+	compatible = "qcom,ukee-mtp", "qcom,ukee", "qcom,mtp";
+	qcom,msm-id = <591 0x10000>;
+	qcom,board-id = <0x10008 0>;
+	xiaomi,miboard-id = <0xf 0>;
+};

--- a/qcom/marble-sm7475-pm8008-overlay.dts
+++ b/qcom/marble-sm7475-pm8008-overlay.dts
@@ -11,3 +11,33 @@
 	qcom,board-id = <0x10008 0>;
 	xiaomi,miboard-id = <0xf 0>;
 };
+
+&L1J {
+	regulator-min-microvolt = <1000000>;
+	regulator-max-microvolt = <1000000>;
+};
+
+&L2J {
+	regulator-min-microvolt = <1200000>;
+	regulator-max-microvolt = <1200000>;
+};
+
+&L3J {
+	regulator-min-microvolt = <2800000>;
+	regulator-max-microvolt = <2800000>;
+};
+
+&L4J {
+	regulator-min-microvolt = <2800000>;
+	regulator-max-microvolt = <2800000>;
+};
+
+&L6J {
+	regulator-min-microvolt = <2800000>;
+	regulator-max-microvolt = <2800000>;
+};
+
+&L7J {
+	regulator-min-microvolt = <2800000>;
+	regulator-max-microvolt = <2800000>;
+};

--- a/qcom/marble-sm7475.dtsi
+++ b/qcom/marble-sm7475.dtsi
@@ -1,0 +1,548 @@
+/*
+   this file is for attribution only of marble
+   And public attribution of xiaomi platforms(like K2 and so and)
+*/
+#include "marble-pinctrl.dtsi"
+#include "xiaomi-sm7475-common.dtsi"
+&qupv3_se15_i2c {
+	status = "ok";
+	/* TOP Smart PA */
+	aw882xx_smartpa@34 {
+		compatible = "awinic,aw882xx_smartpa";
+		reg = <0x34>;
+		irq-gpio = <&tlmm 88 0x2008>;
+		reset-gpio = <&tlmm 1 0x2008>;
+		pinctrl-names = "default","sleep";
+		pinctrl-0 = <&aw882xx_reset_active_top &aw882xx_irq_active_top>;
+		pinctrl-1 = <&aw882xx_reset_suspend_top>;
+		dc-flag = <0>;
+		sync-flag = <1>;
+		sound-channel = <0>;
+		aw-cali-mode = "aw_none ";
+		spksw-gpio = <&tlmm 52 0>;
+		status = "ok";
+	};
+	/* BOT Smart PA */
+	aw882xx_smartpa@35 {
+		compatible = "awinic,aw882xx_smartpa";
+		reg = <0x35>;
+		irq-gpio = <&tlmm 63 0x2008>;
+		reset-gpio = <&tlmm 120 0x2008>;
+		pinctrl-names = "default","sleep";
+		pinctrl-0 = <&aw882xx_reset_active_bot>;
+		pinctrl-1 = <&aw882xx_reset_suspend_bot>;
+		dc-flag = <0>;
+		sync-flag = <1>;
+		sound-channel = <1>;
+		aw-cali-mode = "aw_none ";
+		status = "ok";
+	};
+};
+
+&soc {
+	xiaomi_touch {
+		compatible = "xiaomi-touch";
+		status = "ok";
+		touch,name = "xiaomi-touch";
+	};
+
+	fingerprint_fpc {
+		status = "ok";
+		compatible = "fpc,fpc1020";
+		interrupt-parent = <&tlmm>;
+		interrupts = <40 0x0>;
+		fpc,gpio_rst    = <&tlmm 41 0x0>;
+		fpc,gpio_irq    = <&tlmm 40 0x0>;
+		fp_vdd_vreg-supply = <&L1C>;
+		pinctrl-names = "fpc1020_reset_reset",
+				"fpc1020_reset_active",
+				"fpc1020_irq_active";
+
+		pinctrl-0 = <&msm_gpio_reset>;
+		pinctrl-1 = <&msm_gpio_reset_output_high>;
+		pinctrl-2 = <&msm_gpio_irq>;
+	};
+
+	fingerprint_goodix {
+		compatible = "goodix,fingerprint";
+		l6c_vdd-supply = <&L6C>;
+		goodix,gpio-reset = <&tlmm 41 0x0>;
+		goodix,gpio-irq = <&tlmm 40 0x0>;
+		status = "ok";
+	};
+
+	xiaomi_fingerprint {
+		compatible = "xiaomi-fingerprint";
+		status = "ok";
+		fingerprint,name = "xiaomi-fingerprint";
+	};
+
+	adsp_sleepmon: adsp-sleepmon {
+		compatible = "qcom,adsp-sleepmon";
+		qcom,wait_time_lpm = <45>;
+		qcom,wait_time_lpi = <45>;
+	};
+};
+
+&tlmm {
+	mi_ts_active: mi_ts_active {
+		mux {
+			pins = "gpio20", "gpio21";
+			function = "gpio";
+		};
+
+		config {
+			pins = "gpio20", "gpio21";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+	};
+
+	mi_ts_cs_active: mi_ts_cs_active {
+		mux {
+			pins = "gpio19";
+			function = "qup4";
+		};
+
+		config {
+			pins = "gpio19";
+			drive-strength = <16>;
+			bias-pull-up;
+		};
+	};
+
+	mi_ts_cs_suspend: mi_ts_cs_suspend {
+		mux {
+			pins = "gpio19";
+			function = "gpio";
+		};
+
+		config {
+			pins = "gpio19";
+			drive-strength = <16>;
+			bias-pull-up;
+		};
+	};
+
+	pmx_ts_reset_suspend: pmx_ts_reset_suspend {
+		ts_reset_suspend: ts_reset_suspend {
+			mux {
+				pins = "gpio20";
+				function = "gpio";
+			};
+
+			config {
+				pins = "gpio20";
+				drive-strength = <2>;
+				bias-pull-down;
+			};
+		};
+	};
+
+	pmx_ts_int_suspend: pmx_ts_int_suspend {
+		ts_int_suspend: ts_int_suspend {
+			mux {
+				pins = "gpio21";
+				function = "gpio";
+			};
+
+			config {
+				pins = "gpio21";
+				drive-strength = <2>;
+				bias-pull-down;
+			};
+		};
+	};
+
+	mi_ts_spi_active: qupv3_se4_spi_active {
+		mux {
+			pins = "gpio16", "gpio17", "gpio18";
+			function = "qup4";
+		};
+		config {
+			pins = "gpio16", "gpio17", "gpio18";
+			drive-strength = <6>;
+			bias-disable;
+		};
+	};
+
+	mi_ts_spi_suspend: qupv3_se4_spi_sleep {
+		mux {
+			pins = "gpio16", "gpio17", "gpio18";
+			function = "gpio";
+		};
+		config {
+			pins = "gpio16", "gpio17", "gpio18";
+			drive-strength = <6>;
+			bias-disable;
+		};
+	};
+
+	/* FP_RESET_N */
+	msm_gpio_reset: msm_gpio_reset {
+		mux {
+			pins = "gpio41";
+			function = "gpio";
+		};
+		config {
+			pins = "gpio41";
+			drive-strength = <2>;
+			bias-disable;
+			output-low;
+		};
+	};
+
+	/* FP_RESET_N, state device active*/
+	msm_gpio_reset_output_high: msm_gpio_reset_output_high {
+		mux {
+			pins = "gpio41";
+			function = "gpio";
+		};
+		config {
+			pins = "gpio41";
+			drive-strength = <2>;
+			bias-disable;
+			output-high;
+		};
+	};
+
+	/* FP_INT_N */
+	msm_gpio_irq: msm_gpio_irq {
+		mux {
+			pins = "gpio40";
+			function = "gpio";
+		};
+		config {
+			pins = "gpio40";
+			drive-strength = <2>;
+			bias-pull-down;
+		};
+	};
+};
+
+&L1C {
+	regulator-min-microvolt = <1800000>;
+	regulator-max-microvolt = <1800000>;
+	qcom,init-voltage = <1800000>;
+};
+
+&L2C {
+	regulator-min-microvolt = <1800000>;
+	regulator-max-microvolt = <1800000>;
+	qcom,init-voltage = <1800000>;
+};
+
+&L6C {
+	regulator-min-microvolt = <3300000>;
+	regulator-max-microvolt = <3300000>;
+	qcom,init-voltage = <3300000>;
+};
+
+
+&L9C {
+	regulator-min-microvolt = <3224000>;
+	regulator-max-microvolt = <3224000>;
+	qcom,init-voltage = <3224000>;
+};
+
+&qupv3_se4_spi {
+	status = "ok";
+	qcom,rt;
+	pinctrl-0 = <&mi_ts_spi_active &mi_ts_cs_active>;
+	pinctrl-1 = <&mi_ts_spi_suspend &mi_ts_cs_suspend>;
+	m16t-touch@0 {
+		status = "ok";
+		compatible = "goodix,9916r-spi";
+		reg = <0>;
+		spi-max-frequency = <15000000>;
+		interrupt-parent = <&tlmm>;
+		interrupts = <21 0x2008>;
+		pinctrl-names = "pmx_ts_active", "pmx_ts_suspend";
+		pinctrl-0 = <&mi_ts_active>;
+		pinctrl-1 = <&ts_int_suspend &ts_reset_suspend>;
+		iovdd-supply = <&L2C>;
+		avdd-supply = <&L9C>;
+		goodix,iovdd-name = "iovdd";
+		goodix,avdd-name = "avdd";
+		goodix,irq-gpio = <&tlmm 21 0x2008>;
+		goodix,irq-flags = <2>;
+		goodix,reset-gpio = <&tlmm 20 0x00>;
+		goodix,panel-max-x = <1080>;
+		goodix,panel-max-y = <2400>;
+		goodix,panel-max-w = <255>;
+		goodix,panel-max-p = <4096>;
+		goodix,firmware-name = "goodix_firmware_TM.bin";
+		goodix,config-name = "goodix_cfg_group_TM.bin";
+		goodix,touch-expert-array = <2 3 2 2
+					     4 3 3 2
+					     3 3 4 2>;
+	};
+};
+
+&pmk8350_vadc {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pm8350b_rear_tof_therm_default>;
+
+	pm8350_msm_therm {
+		reg = <PM8350_ADC7_AMUX_THM1_100K_PU>;
+		label = "pm8350_msm_therm";
+		qcom,ratiometric;
+		qcom,hw-settle-time = <200>;
+		qcom,pre-scaling = <1 1>;
+	};
+
+	pm8350_cam_flash_therm {
+		reg = <PM8350_ADC7_AMUX_THM2_100K_PU>;
+		label = "pm8350_cam_flash_therm";
+		qcom,ratiometric;
+		qcom,hw-settle-time = <200>;
+		qcom,pre-scaling = <1 1>;
+	};
+
+	pm8350_hot_pocket_therm {
+		reg = <PM8350_ADC7_AMUX_THM3_100K_PU>;
+		label = "pm8350_hot_pocket_therm";
+		qcom,ratiometric;
+		qcom,hw-settle-time = <200>;
+		qcom,pre-scaling = <1 1>;
+	};
+
+	pm8350_wide_rfc_therm {
+		reg = <PM8350B_ADC7_GPIO4_100K_PU>;
+		label = "pm8350_wide_rfc_therm";
+		qcom,ratiometric;
+		qcom,hw-settle-time = <200>;
+		qcom,pre-scaling = <1 1>;
+	};
+
+	pm8350b_rear_tof_therm {
+		reg = <PM8350B_ADC7_AMUX_THM4_100K_PU>;
+		label = "pm8350b_rear_tof_therm";
+		qcom,ratiometric;
+		qcom,hw-settle-time = <200>;
+		qcom,pre-scaling = <1 1>;
+	};
+
+	pm8350b_usb_conn_therm {
+		reg = <PMR735A_ADC7_GPIO1_100K_PU>;
+		label = "pm8350b_usb_conn_therm";
+		qcom,ratiometric;
+		qcom,hw-settle-time = <200>;
+		qcom,pre-scaling = <1 1>;
+	};
+
+	pm8350b_wl_chg_therm {
+		reg = <PMR735A_ADC7_GPIO2_100K_PU>;
+		label = "pm8350b_wl_chg_therm";
+		qcom,ratiometric;
+		qcom,hw-settle-time = <200>;
+		qcom,pre-scaling = <1 1>;
+	};
+
+	pmk8350_xo_therm {
+		reg = <PMR735A_ADC7_GPIO3_100K_PU>;
+		label = "pmk8350_xo_therm";
+		qcom,ratiometric;
+		qcom,hw-settle-time = <200>;
+		qcom,pre-scaling = <1 1>;
+	};
+};
+
+&pmk8350_adc_tm {
+	io-channels = <&pmk8350_vadc PM8350_ADC7_AMUX_THM1_100K_PU>,
+			<&pmk8350_vadc PM8350_ADC7_AMUX_THM2_100K_PU>,
+			<&pmk8350_vadc PM8350_ADC7_AMUX_THM3_100K_PU>,
+			<&pmk8350_vadc PM8350B_ADC7_GPIO4_100K_PU>,
+			<&pmk8350_vadc PM8350B_ADC7_AMUX_THM4_100K_PU>,
+			<&pmk8350_vadc PMR735A_ADC7_GPIO1_100K_PU>,
+			<&pmk8350_vadc PMR735A_ADC7_GPIO2_100K_PU>,
+			<&pmk8350_vadc PMR735A_ADC7_GPIO3_100K_PU>;
+
+	pm8350_msm_therm {
+		reg = <PM8350_ADC7_AMUX_THM1_100K_PU>;
+		qcom,ratiometric;
+		qcom,hw-settle-time = <200>;
+	};
+
+	pm8350_cam_flash_therm {
+		reg = <PM8350_ADC7_AMUX_THM2_100K_PU>;
+		qcom,ratiometric;
+		qcom,hw-settle-time = <200>;
+	};
+
+	pm8350_hot_pocket_therm {
+		reg = <PM8350_ADC7_AMUX_THM3_100K_PU>;
+		qcom,ratiometric;
+		qcom,hw-settle-time = <200>;
+	};
+
+	pm8350_wide_rfc_therm {
+		reg = <PM8350B_ADC7_GPIO4_100K_PU>;
+		qcom,ratiometric;
+		qcom,hw-settle-time = <200>;
+	};
+
+	pm8350b_rear_tof_therm {
+		reg = <PM8350B_ADC7_AMUX_THM4_100K_PU>;
+		qcom,ratiometric;
+		qcom,hw-settle-time = <200>;
+	};
+
+	pm8350b_usb_conn_therm {
+		reg = <PMR735A_ADC7_GPIO1_100K_PU>;
+		qcom,ratiometric;
+		qcom,hw-settle-time = <200>;
+	};
+
+	pm8350b_wl_chg_therm {
+		reg = <PMR735A_ADC7_GPIO2_100K_PU>;
+		qcom,ratiometric;
+		qcom,hw-settle-time = <200>;
+	};
+
+	pmk8350_xo_therm {
+		reg = <PMR735A_ADC7_GPIO3_100K_PU>;
+		qcom,ratiometric;
+		qcom,hw-settle-time = <200>;
+	};
+};
+
+&thermal_zones {
+	cpu_therm {
+		polling-delay-passive = <0>;
+		polling-delay = <0>;
+		thermal-governor = "user_space";
+		thermal-sensors = <&pmk8350_adc_tm PM8350_ADC7_AMUX_THM1_100K_PU>;
+		wake-capable-sensor;
+		trips {
+			active-config0 {
+				temperature = <125000>;
+				hysteresis = <1000>;
+				type = "passive";
+			};
+		};
+	};
+
+	flash_therm {
+		polling-delay-passive = <0>;
+		polling-delay = <0>;
+		thermal-governor = "user_space";
+		thermal-sensors = <&pmk8350_adc_tm PM8350_ADC7_AMUX_THM2_100K_PU>;
+		wake-capable-sensor;
+		trips {
+			active-config0 {
+				temperature = <125000>;
+				hysteresis = <1000>;
+				type = "passive";
+			};
+		};
+	};
+
+	quiet_therm {
+		polling-delay-passive = <0>;
+		polling-delay = <0>;
+		thermal-governor = "user_space";
+		thermal-sensors = <&pmk8350_adc_tm PM8350_ADC7_AMUX_THM3_100K_PU>;
+		wake-capable-sensor;
+		trips {
+			active-config0 {
+				temperature = <125000>;
+				hysteresis = <1000>;
+				type = "passive";
+			};
+		};
+	};
+
+	charger_therm0 {
+		polling-delay-passive = <0>;
+		polling-delay = <0>;
+		thermal-governor = "user_space";
+		thermal-sensors = <&pmk8350_adc_tm PM8350B_ADC7_GPIO4_100K_PU>;
+		wake-capable-sensor;
+		trips {
+			active-config0 {
+				temperature = <125000>;
+				hysteresis = <1000>;
+				type = "passive";
+			};
+		};
+	};
+
+	conn_therm {
+		polling-delay-passive = <0>;
+		polling-delay = <0>;
+		thermal-governor = "user_space";
+		thermal-sensors = <&pmk8350_adc_tm PM8350B_ADC7_AMUX_THM4_100K_PU>;
+		wake-capable-sensor;
+		trips {
+			active-config0 {
+				temperature = <125000>;
+				hysteresis = <1000>;
+				type = "passive";
+			};
+		};
+	};
+
+	pa_therm0 {
+		polling-delay-passive = <0>;
+		polling-delay = <0>;
+		thermal-governor = "user_space";
+		thermal-sensors = <&pmk8350_adc_tm PMR735A_ADC7_GPIO1_100K_PU>;
+		wake-capable-sensor;
+		trips {
+			active-config0 {
+				temperature = <125000>;
+				hysteresis = <1000>;
+				type = "passive";
+			};
+		};
+	};
+
+	pa_therm1 {
+		polling-delay-passive = <0>;
+		polling-delay = <0>;
+		thermal-governor = "user_space";
+		thermal-sensors = <&pmk8350_adc_tm PMR735A_ADC7_GPIO2_100K_PU>;
+		wake-capable-sensor;
+		trips {
+			active-config0 {
+				temperature = <125000>;
+				hysteresis = <1000>;
+				type = "passive";
+			};
+		};
+	};
+
+	wifi_therm {
+		polling-delay-passive = <0>;
+		polling-delay = <0>;
+		thermal-governor = "user_space";
+		thermal-sensors = <&pmk8350_adc_tm PMR735A_ADC7_GPIO3_100K_PU>;
+		wake-capable-sensor;
+		trips {
+			active-config0 {
+				temperature = <125000>;
+				hysteresis = <1000>;
+				type = "passive";
+			};
+		};
+	};
+};
+
+&nxp_eusb2_repeater {
+        qcom,param-override-seq =
+                <0x62 0x08
+                0x10 0x07>;
+        qcom,param-override-seq-host =
+                <0x62 0x08
+                0x10 0x07
+                0x1 0xa>;
+};
+
+&battery_charger {
+	mi,support-soc-update;
+};
+
+&ufshc_mem {
+	qcom,iommu-dma = "bypass";
+};

--- a/qcom/marble-sm7475.dtsi
+++ b/qcom/marble-sm7475.dtsi
@@ -18,7 +18,7 @@
 		dc-flag = <0>;
 		sync-flag = <1>;
 		sound-channel = <0>;
-		aw-cali-mode = "aw_none ";
+		aw-cali-mode = "none";
 		spksw-gpio = <&tlmm 52 0>;
 		status = "ok";
 	};
@@ -34,7 +34,7 @@
 		dc-flag = <0>;
 		sync-flag = <1>;
 		sound-channel = <1>;
-		aw-cali-mode = "aw_none ";
+		aw-cali-mode = "none";
 		status = "ok";
 	};
 };

--- a/qcom/marble-sm7475.dtsi
+++ b/qcom/marble-sm7475.dtsi
@@ -271,8 +271,10 @@
 		goodix,panel-max-y = <2400>;
 		goodix,panel-max-w = <255>;
 		goodix,panel-max-p = <4096>;
-		goodix,firmware-name = "goodix_firmware_TM.bin";
-		goodix,config-name = "goodix_cfg_group_TM.bin";
+		goodix,firmware-namea = "goodix_firmware_TM.bin";
+		goodix,firmware-nameb = "goodix_firmware_TM_Second.bin";
+		goodix,config-namea = "goodix_cfg_group_TM.bin";
+		goodix,config-nameb = "goodix_cfg_group_TM_Second.bin";
 		goodix,touch-expert-array = <2 3 2 2
 					     4 3 3 2
 					     3 3 4 2>;

--- a/qcom/waipio.dtsi
+++ b/qcom/waipio.dtsi
@@ -1363,7 +1363,7 @@
 		clocks = <&clock_rpmh RPMH_CXO_CLK>;
 		clock-names = "xo";
 		qcom,proxy-clock-names = "xo";
-		status = "ok";
+		status = "disabled";
 
 		memory-region = <&spss_region_mem>;
 		qcom,spss-scsr-bits = <24 25>;
@@ -1406,7 +1406,7 @@
 		/* soc2sp rmb shared register physical address */
 		qcom,spcom-soc2sp-rmb-reg-addr = <0x01881030>;
 		qcom,spcom-soc2sp-rmb-sp-ssr-bit = <0>;
-		status = "ok";
+		status = "disabled";
 	};
 
 	spss_utils: qcom,spss_utils {
@@ -1426,7 +1426,7 @@
 		qcom,spss-emul-type-reg-addr = <0x01fc8004>;
 		pil-mem = <&spss_region_mem>;
 		qcom,pil-size = <0x0F0000>; // padding to 960KB
-		status = "ok";
+		status = "disabled";
 	};
 
 	qcom,pmic_glink {

--- a/qcom/xiaomi-sm7475-common.dtsi
+++ b/qcom/xiaomi-sm7475-common.dtsi
@@ -1,0 +1,47 @@
+#include "xiaomi-sm8475-common.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+&soc {
+	gpio_keys {
+		compatible = "gpio-keys";
+		label = "gpio-keys";
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&key_vol_up_default>;
+
+		vol_up {
+			label = "volume_up";
+			gpios = <&pm8350_gpios 6 GPIO_ACTIVE_LOW>;
+			linux,input-type = <1>;
+			linux,code = <KEY_VOLUMEUP>;
+			gpio-key,wakeup;
+			debounce-interval = <15>;
+			linux,can-disable;
+		};
+	};
+};
+
+&pm8350c_switch0 {
+	qcom,led-mask = <9>; /* Channels 1 & 4 */
+	qcom,symmetry-en;
+};
+
+&pm8350c_switch1 {
+	qcom,led-mask = <6>; /* Channels 2 & 3 */
+	qcom,symmetry-en;
+};
+
+&pm8350c_switch2 {
+	qcom,led-mask = <15>; /* All Channels */
+	qcom,symmetry-en;
+};
+
+&pm8350c_flash {
+	status = "ok";
+};
+
+&battery_charger {
+	qcom,thermal-mitigation = <3000000 1500000 1000000 500000>;
+	qcom,wireless-fw-name = "idt9415.bin";
+};

--- a/qcom/xiaomi-sm7475-common.dtsi
+++ b/qcom/xiaomi-sm7475-common.dtsi
@@ -22,6 +22,11 @@
 	};
 };
 
+&pm8350b_haptics {
+	qcom,vmax-mv = <1450>;
+	qcom,lra-period-us = <5882>;
+};
+
 &pm8350c_switch0 {
 	qcom,led-mask = <9>; /* Channels 1 & 4 */
 	qcom,symmetry-en;


### PR DESCRIPTION
By reading the official documentation of awinic [1], we can know that this is the calibration function of the aw882xx chip.

We should disable it for these reasons:

1. The calibration file is located in "/mnt/vendor/persist/factory/audio/aw_cali.bin" [2], but this file does not exist in our device (marble).
2. The value of the old "aw-cali-mode" attribute is "aw_none ", and it is obvious that Xiaomi does not intend to enable it [3].
3. Users and system should not adjust the calibration data, which will affect the sound effect of the speaker.

[1]: https://t.me/paradoxkernelmarblediscussion/32932
[2]: https://github.com/MiCode/vendor_qcom_opensource_audio-kernel/blob/7d174adfe5304b74889e0cf0e16132a049707710/asoc/codecs/aw882xx/src/aw882xx_calib.c#L57
[3]: https://github.com/MiCode/vendor_qcom_opensource_audio-kernel/blob/7d174adfe5304b74889e0cf0e16132a049707710/asoc/codecs/aw882xx/src/aw882xx_calib.c#L2338