### PR TITLE
devicetree: ukee: Set the initial power level of the GPU to 6

### DIFF
--- a/qcom/ukee.dtsi
+++ b/qcom/ukee.dtsi
@@ -7,7 +7,7 @@
 };
 
 &msm_gpu {
-	qcom,initial-pwrlevel = <5>;
+	qcom,initial-pwrlevel = <6>;
 
 	/delete-property/qcom,gpu-model;
 	qcom,gpu-model = "Adreno725v1";


### PR DESCRIPTION
Otherwise the GPU is always at 285MHz when the device is idle, instead of the lowest 220MHz.

This helps save power.